### PR TITLE
Send userSync cookies

### DIFF
--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -55,7 +55,7 @@ function _createServerRequest(bidRequest) {
    */
   const options = {
     contentType: 'application/json',
-    withCredentials: false
+    withCredentials: true
   };
   // Allow the ability to configure the HB endpoint for testing purposes.
   const ttxSettings = config.getConfig('ttxSettings');

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -146,7 +146,7 @@ describe('33acrossBidAdapter:', function () {
         'data': JSON.stringify(ttxRequest),
         'options': {
           'contentType': 'application/json',
-          'withCredentials': false
+          'withCredentials': true
         }
       }
       const builtServerRequests = buildRequests(this.bidRequests);
@@ -194,7 +194,7 @@ describe('33acrossBidAdapter:', function () {
         data: JSON.stringify(ttxRequest),
         options: {
           contentType: 'application/json',
-          withCredentials: false
+          withCredentials: true
         }
       };
 
@@ -244,7 +244,7 @@ describe('33acrossBidAdapter:', function () {
         data: JSON.stringify(ttxRequest),
         options: {
           contentType: 'application/json',
-          withCredentials: false
+          withCredentials: true
         }
       };
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- 33Across exchange server now CORS with credentials. So send cookies for user sync. NOTE: this completes the implementation of user syncing

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
aparna.hegde@33across.com

- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
