### PR TITLE
Sync based on unique site id

### DIFF
--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -418,27 +418,54 @@ describe('33acrossBidAdapter:', function () {
           url: 'https://de.tynt.com/deb/v2?m=xch&rt=html&id=id2'
         },
       ];
+      this.bidRequests = [
+        {
+          bidId: 'b1',
+          bidder: '33across',
+          bidderRequestId: 'b1a',
+          params: {
+            siteId: 'id1',
+            productId: 'foo'
+          },
+          adUnitCode: 'div-id',
+          auctionId: 'r1',
+          sizes: [
+            [ 300, 250 ]
+          ],
+          transactionId: 't1'
+        },
+        {
+          bidId: 'b2',
+          bidder: '33across',
+          bidderRequestId: 'b2a',
+          params: {
+            siteId: 'id2',
+            productId: 'foo'
+          },
+          adUnitCode: 'div-id',
+          auctionId: 'r1',
+          sizes: [
+            [ 300, 250 ]
+          ],
+          transactionId: 't2'
+        }
+      ];
     });
 
     context('when iframe is not enabled', function() {
       it('returns empty sync array', function() {
-        this.sandbox.stub(config, 'getConfig').callsFake(() => {
-          return  ['id1', 'id1', 'id2'];
-        });
         const syncOptions = {};
+        buildRequests(this.bidRequests);
         expect(getUserSyncs(syncOptions)).to.deep.equal([]);
       });
     });
 
     context('when iframe is enabled', function() {
       it('returns sync array equal to number of unique siteIDs', function() {
-        this.sandbox.stub(config, 'getConfig').callsFake(() => {
-          return  ['id1', 'id1', 'id2'];
-        });
-
         const syncOptions = {
           iframeEnabled: true
         };
+        buildRequests(this.bidRequests);
         const syncs = getUserSyncs(syncOptions);
         expect(syncs).to.deep.equal(this.syncs);
       });

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -404,43 +404,43 @@ describe('33acrossBidAdapter:', function () {
         expect(interpretResponse({ body: serverResponse }, this.serverRequest)).to.deep.equal([ bidResponse ]);
       });
     });
+  });
 
-    context('and register user sync', function() {
-      it('via the production endpoint', function() {
-        const spy = this.sandbox.spy(userSync, 'registerSync');
-        const serverResponse = {
-          cur: 'USD',
-          ext: {},
-          id: 'b1',
-          seatbid: []
-        }
-        interpretResponse({ body: serverResponse }, this.serverRequest);
-        const syncUrl = `${SYNC_ENDPOINT}&id=${this.ttxRequest.site.id}`;
+  describe('getUserSyncs', function() {
+    beforeEach(function() {
+      this.syncs = [
+        {
+          type: 'iframe',
+          url: 'https://de.tynt.com/deb/v2?m=xch&rt=html&id=id1'
+        },
+        {
+          type: 'iframe',
+          url: 'https://de.tynt.com/deb/v2?m=xch&rt=html&id=id2'
+        },
+      ];
+    });
 
-        const registerSyncCalled = spy.calledWith('iframe', '33across', syncUrl);
-        expect(registerSyncCalled).to.be.true;
-      });
-
-      it('via the test endpoint', function() {
-        const spy = this.sandbox.spy(userSync, 'registerSync');
-
+    context('when iframe is not enabled', function() {
+      it('returns empty sync array', function() {
         this.sandbox.stub(config, 'getConfig').callsFake(() => {
-          return {
-            'syncUrl': 'https://foo.com/deb/v2?m=xch'
-          }
+          return  ['id1', 'id1', 'id2'];
+        });
+        const syncOptions = {};
+        expect(getUserSyncs(syncOptions)).to.deep.equal([]);
+      });
+    });
+
+    context('when iframe is enabled', function() {
+      it('returns sync array equal to number of unique siteIDs', function() {
+        this.sandbox.stub(config, 'getConfig').callsFake(() => {
+          return  ['id1', 'id1', 'id2'];
         });
 
-        const serverResponse = {
-          cur: 'USD',
-          ext: {},
-          id: 'b1',
-          seatbid: []
-        }
-        interpretResponse({ body: serverResponse }, this.serverRequest);
-        const syncUrl = `https://foo.com/deb/v2?m=xch&id=${this.ttxRequest.site.id}`;
-
-        const registerSyncCalled = spy.calledWith('iframe', '33across', syncUrl);
-        expect(registerSyncCalled).to.be.true;
+        const syncOptions = {
+          iframeEnabled: true
+        };
+        const syncs = getUserSyncs(syncOptions);
+        expect(syncs).to.deep.equal(this.syncs);
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
User sync based on unique site across all bid requests rather than bid request count. This eliminates unnecessary calls and avoid hitting sync limits.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
