### PR TITLE
Oculus 82 locate ad slot element by ad slot path

### DIFF
--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -283,15 +283,10 @@ function isBidRequestValid(bid) {
 // - the server, at this point, also doesn't need the consent string to handle gdpr compliance. So passing
 //    value whether set or not, for the sake of future dev.
 function buildRequests(bidRequests, bidderRequest) {
-  // const gdprConsent = Object.assign({
-  //   consentString: undefined,
-  //   gdprApplies: false
-  // }, bidderRequest && bidderRequest.gdprConsent);
-  const gdprConsent = {
-    gdprApplies: false,
-    consentString: undefined, // see comment about this
-    ...(bidderRequest && bidderRequest.gdprConsent)
-  };
+  const gdprConsent = Object.assign({
+    consentString: undefined,
+    gdprApplies: false
+  }, bidderRequest && bidderRequest.gdprConsent);
 
   adapterState.uniqueSiteIds = bidRequests.map(req => req.params.siteId).filter(utils.uniques);
 

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -294,8 +294,6 @@ function buildRequests(bidRequests, bidderRequest) {
 
   adapterState.uniqueSiteIds = bidRequests.map(req => req.params.siteId).filter(utils.uniques);
 
-  utils.logInfo('[33Across Adapter] buildRequests():', bidRequests);
-
   return bidRequests.map(req => _createServerRequest(req, gdprConsent));
 }
 

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -58,7 +58,7 @@ function _getAdSlotHTMLElement(adUnitCode) {
     document.getElementById(_mapAdUnitPathToElementId(adUnitCode));
 
   if (element === null) {
-    utils.logWarn(`[33Across Adapter] Unable to locate element with id: '${adUnitCode}'`);
+    utils.logWarn(`[33Across Adapter] Unable to locate element for ad unit code: '${adUnitCode}'`);
   }
 
   return element;

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -53,7 +53,11 @@ function getAdSlotHTMLElement(adUnitCode) {
   let element = document.getElementById(adUnitCode);
 
   if (element === null) {
-    element = document.getElementById(mapAdSlotPathToElementId(adUnitCode));
+    const id = mapAdSlotPathToElementId(adUnitCode);
+
+    element = document.getElementById(id);
+
+    utils.logInfo(`Trying to map ad unit path to HTML element id: '${adUnitCode}' -> '${id}'`);
   }
 
   return element;
@@ -75,7 +79,7 @@ function _createServerRequest(bidRequest, gdprConsent) {
   const contributeViewability = ViewabilityContributor(viewabilityAmount);
 
   if (element === null) {
-    utils.logWarn(`Unable to locate element with id: '${bidRequest.adUnitCode}'`);
+    utils.logWarn(`[33Across Adapter] Unable to locate element with id: '${bidRequest.adUnitCode}'`);
   }
 
   /*
@@ -289,6 +293,8 @@ function buildRequests(bidRequests, bidderRequest) {
   const gdprConsent = Object.assign({ consentString: undefined, gdprApplies: false }, bidderRequest && bidderRequest.gdprConsent);
 
   adapterState.uniqueSiteIds = bidRequests.map(req => req.params.siteId).filter(utils.uniques);
+
+  util.logInfo('[33Across Adapter] buildRequests():', bidRequests);
 
   return bidRequests.map(req => _createServerRequest(req, gdprConsent));
 }

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -52,7 +52,7 @@ function _mapAdUnitPathToElementId(adUnitCode) {
 
   utils.logWarn(`[33Across Adapter] Unable to locate element for ad unit code: '${adUnitCode}'`);
 
-  return null;
+  return id;
 }
 
 function _getAdSlotHTMLElement(adUnitCode) {

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -31,7 +31,7 @@ function _isViewabilityMeasurable(element) {
 }
 
 function _getViewability(element, topWin, { w, h } = {}) {
-  return utils.getWindowTop().document.visibilityState === 'visible'
+  return topWin.document.visibilityState === 'visible'
     ? _getPercentInView(element, topWin, { w, h })
     : 0;
 }
@@ -290,11 +290,14 @@ function isBidRequestValid(bid) {
 // - the server, at this point, also doesn't need the consent string to handle gdpr compliance. So passing
 //    value whether set or not, for the sake of future dev.
 function buildRequests(bidRequests, bidderRequest) {
-  const gdprConsent = Object.assign({ consentString: undefined, gdprApplies: false }, bidderRequest && bidderRequest.gdprConsent);
+  const gdprConsent = Object.assign({
+    consentString: undefined,
+    gdprApplies: false
+  }, bidderRequest && bidderRequest.gdprConsent);
 
   adapterState.uniqueSiteIds = bidRequests.map(req => req.params.siteId).filter(utils.uniques);
 
-  util.logInfo('[33Across Adapter] buildRequests():', bidRequests);
+  utils.logInfo('[33Across Adapter] buildRequests():', bidRequests);
 
   return bidRequests.map(req => _createServerRequest(req, gdprConsent));
 }

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -37,22 +37,22 @@ function _getViewability(element, topWin, { w, h } = {}) {
 }
 
 function _mapAdUnitPathToElementId(adUnitCode) {
-  let id = null;
-
   if (utils.isGptPubadsDefined()) {
     const isMatchingAdSlot = utils.isSlotMatchingAdUnitCode(adUnitCode);
     const matchingAdSlot = window.googletag.pubads().getSlots().find(isMatchingAdSlot);
 
     if (matchingAdSlot) {
-      id = matchingAdSlot.getSlotElementId();
+      const id = matchingAdSlot.getSlotElementId();
 
-      utils.logInfo(`[33Across Adapter] Map ad unit path to HTML element id: '${adUnitCode}' -> '${id}'`);
+      utils.logInfo(`[33Across Adapter] Map ad unit path to HTML element id: '${adUnitCode}' -> ${id}`);
+
+      return id;
     }
   }
 
   utils.logWarn(`[33Across Adapter] Unable to locate element for ad unit code: '${adUnitCode}'`);
 
-  return id;
+  return null;
 }
 
 function _getAdSlotHTMLElement(adUnitCode) {

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -45,23 +45,19 @@ function _mapAdUnitPathToElementId(adUnitCode) {
 
     if (matchingAdSlot) {
       id = matchingAdSlot.getSlotElementId();
+
+      utils.logInfo(`[33Across Adapter] Map ad unit path to HTML element id: '${adUnitCode}' -> '${id}'`);
     }
   }
 
-  utils.logInfo(`[33Across Adapter] Map ad unit path to HTML element id: '${adUnitCode}' -> '${id}'`);
+  utils.logWarn(`[33Across Adapter] Unable to locate element for ad unit code: '${adUnitCode}'`);
 
-  return id;
+  return null;
 }
 
 function _getAdSlotHTMLElement(adUnitCode) {
-  const element = document.getElementById(adUnitCode) ||
+  return document.getElementById(adUnitCode) ||
     document.getElementById(_mapAdUnitPathToElementId(adUnitCode));
-
-  if (element === null) {
-    utils.logWarn(`[33Across Adapter] Unable to locate element for ad unit code: '${adUnitCode}'`);
-  }
-
-  return element;
 }
 
 // Infer the necessary data from valid bid for a minimal ttxRequest and create HTTP request
@@ -287,10 +283,15 @@ function isBidRequestValid(bid) {
 // - the server, at this point, also doesn't need the consent string to handle gdpr compliance. So passing
 //    value whether set or not, for the sake of future dev.
 function buildRequests(bidRequests, bidderRequest) {
-  const gdprConsent = Object.assign({
-    consentString: undefined,
-    gdprApplies: false
-  }, bidderRequest && bidderRequest.gdprConsent);
+  // const gdprConsent = Object.assign({
+  //   consentString: undefined,
+  //   gdprApplies: false
+  // }, bidderRequest && bidderRequest.gdprConsent);
+  const gdprConsent = {
+    gdprApplies: false,
+    consentString: undefined, // see comment about this
+    ...(bidderRequest && bidderRequest.gdprConsent)
+  };
 
   adapterState.uniqueSiteIds = bidRequests.map(req => req.params.siteId).filter(utils.uniques);
 

--- a/modules/33acrossBidAdapter.md
+++ b/modules/33acrossBidAdapter.md
@@ -16,7 +16,7 @@ Connects to 33Across's exchange for bids.
 ```
 var adUnits = [
 {
-    code: '33across-hb-ad-123456-1',    
+    code: '33across-hb-ad-123456-1', // ad slot HTML element ID   
     sizes: [
         [300, 250], 
         [728, 90]

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -337,8 +337,8 @@ describe('33acrossBidAdapter:', function () {
 
         utils.getWindowTop.restore();
         utils.getWindowSelf.restore();
-        sandbox.stub(utils, 'getWindowTop').returns(win);
-        sandbox.stub(utils, 'getWindowSelf').returns({});
+        sandbox.stub(utils, 'getWindowTop').returns({});
+        sandbox.stub(utils, 'getWindowSelf').returns(win);
 
         expect(spec.buildRequests(bidRequests)).to.deep.equal([ serverRequest ]);
       });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Use GPT to map ad unit path to HTML element id.
