### PR TITLE
Adding schain info

### DIFF
--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -175,7 +175,7 @@ function _getSchainInfo(schain) {
 // of the above conditions fail.
 function _isValidSchain(schain) {
   //Check of nodes are valid
-  if(!schain.nodes || !schain.nodes.length > 0) {
+  if(!schain.nodes || !(schain.nodes.length > 0)) {
     return false;
   }
 

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -127,7 +127,11 @@ function _createServerRequest(bidRequest, gdprConsent = {}, uspConsent, pageUrl)
   };
   
   if(bidRequest.schain) {
-    ttxRequest.source = _getSchainInfo(bidRequest.schain);
+    ttxRequest.source = {
+      ext: {
+        schain: bidRequest.schain
+      }
+    }
   }
   
   // Finally, set the openRTB 'test' param if this is to be a test bid
@@ -154,42 +158,6 @@ function _createServerRequest(bidRequest, gdprConsent = {}, uspConsent, pageUrl)
     'data': JSON.stringify(contributeViewability(ttxRequest)),
     'options': options
   }
-}
-
-function _getSchainInfo(schain) {
-  if(_isValidSchain(schain)) {
-    return {
-      ext: { schain }
-    }
-  } else {
-    utils.logWarn('[33Across Adapter] Invalid schain info passed');
-    return null;
-  }
-}
-
-// We validate schain as follows:
-//  - Complete status must be 0|1
-//  - Nodes must be defined and non-empty array
-//  - Each node must contain all the required fields
-// The entire schain schain object is marked as invalid i.e. return false if any 
-// of the above conditions fail.
-function _isValidSchain(schain) {
-  //Check of nodes are valid
-  if(!schain.nodes || !(schain.nodes.length > 0)) {
-    return false;
-  }
-
-  //Check is complete status is valid
-  if(schain.complete !== 0 && schain.complete !== 1) {
-    return false;
-  }
-
-  // Check for required fields in nodes
-  const requiredFields = ['asi', 'sid', 'hp'];
-
-  return schain.nodes.every((node)=> {
-    return requiredFields.every((field)=> node[field]);
-  });
 }
 
 // Sync object will always be of type iframe for TTX

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -602,54 +602,20 @@ describe('33acrossBidAdapter:', function () {
       });
     });
 
-    context('when there is valid schain object in the bidRequest', function() {
+    context('when there is schain object in the bidRequest', function() {
       it('builds request with schain info in source', function() {
-        const schain = {
-          'ver': "1.0",
-          'complete': 1,
-          'nodes': [
-            {
-              'asi': "bidderA.com",
-              'sid': "00001",
-              'hp': 1
-            }
-          ]
-        };
-
-        bidRequests[0].schain = schain;
-
-        const ttxRequest = new TtxRequestBuilder()
-          .withSchain(schain)
-          .build();
-        const serverRequest = new ServerRequestBuilder()
-          .withData(ttxRequest)
-          .build();
-
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
-
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
-
-      });
-    });
-
-    context('when there no schain object is passed', function() {
-      it('does not set source field', function() {
-        const ttxRequest = new TtxRequestBuilder()
-        .build();
-        
-        const serverRequest = new ServerRequestBuilder()
-        .withData(ttxRequest)
-        .build();
-
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
-
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
-      });
-    });
-
-    context('when invalid schain object is passed in the bidRequest', function() {
-      it('builds request with source set to null', function() {
-        const invalidSchainValues = [
+        const schainValues = [
+          {
+            'ver': "1.0",
+            'complete': 1,
+            'nodes': [
+              {
+                'asi': "bidderA.com",
+                'sid': "00001",
+                'hp': 1
+              }
+            ]
+          },
           {
             'ver': "1.0",
             'complete': 1,
@@ -669,48 +635,38 @@ describe('33acrossBidAdapter:', function () {
                 'hp': 1
               }
             ]
-          },
-          {
-            'ver': "1.0",
-            'complete': 1,
-            'nodes': [
-              {
-                'sid': "00001",
-                'hp': 1
-              }
-            ]
-          },
-          {
-            'ver': "1.0",
-            'complete': 0,
-            'nodes': [
-              {
-                'asi': "",
-                'sid': "00001",
-                'hp': 1,
-              }
-            ]
           }
-        ]
+        ];
 
-        invalidSchainValues.forEach((schain)=> {
+        schainValues.forEach((schain)=> {
           bidRequests[0].schain = schain;
 
           const ttxRequest = new TtxRequestBuilder()
             .withSchain(schain)
             .build();
-          
-          ttxRequest.source = null;
-
           const serverRequest = new ServerRequestBuilder()
             .withData(ttxRequest)
             .build();
   
-          
           const builtServerRequests = spec.buildRequests(bidRequests, {});
   
           expect(builtServerRequests).to.deep.equal([serverRequest]);
-        });
+        }); 
+      });
+    });
+
+    context('when there no schain object is passed', function() {
+      it('does not set source field', function() {
+        const ttxRequest = new TtxRequestBuilder()
+        .build();
+        
+        const serverRequest = new ServerRequestBuilder()
+        .withData(ttxRequest)
+        .build();
+
+        const builtServerRequests = spec.buildRequests(bidRequests, {});
+
+        expect(builtServerRequests).to.deep.equal([serverRequest]);
       });
     });
   });

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -652,11 +652,11 @@ describe('33acrossBidAdapter:', function () {
         const invalidSchainValues = [
           {
             'ver': "1.0",
-            'complete': '1',
+            'complete': 1,
           },
           {
             'ver': "1.0",
-            'complete': '1',
+            'complete': 1,
             'nodes': []
           },
           {
@@ -672,11 +672,22 @@ describe('33acrossBidAdapter:', function () {
           },
           {
             'ver': "1.0",
-            'complete': '1',
+            'complete': 1,
             'nodes': [
               {
                 'sid': "00001",
                 'hp': 1
+              }
+            ]
+          },
+          {
+            'ver': "1.0",
+            'complete': 0,
+            'nodes': [
+              {
+                'asi': "",
+                'sid': "00001",
+                'hp': 1,
               }
             ]
           }


### PR DESCRIPTION
Schain Info is added as follows:
- If schain object exists in `bidRequests` (the object that prebid passes to adapter during bid request phased to build and send requests) then try to infer schain
- If schain info is valid then add it to the `source` field.
- If schain info passed is not valid then set `source` to null