### PR TITLE
First cut for bidfloors support

### DIFF
--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -69,16 +69,18 @@ function _getAdSlotHTMLElement(adUnitCode) {
 
 // Infer the necessary data from valid bid for a minimal ttxRequest and create HTTP request
 // NOTE: At this point, TTX only accepts request for a single impression
-function _createServerRequest({bidRequest, gdprConsent = {}, uspConsent, pageUrl, getFloor}) {
+function _createServerRequest({bidRequest, gdprConsent = {}, uspConsent, pageUrl}) {
   const ttxRequest = {};
   const params = bidRequest.params;
   const element = _getAdSlotHTMLElement(bidRequest.adUnitCode);
   const sizes = _transformSizes(bidRequest.sizes);
-  
+
   let format;
 
   // We support size based bidfloors so obtain one if there's a rule associated
-  if (typeof getFloor === 'function') {
+  if (typeof bidRequest.getFloor === 'function') {
+    let getFloor = bidRequest.getFloor.bind(bidRequest);
+
     format = sizes.map((size) => {
       const formatExt = _getBidFloors(getFloor, size);
 
@@ -199,7 +201,7 @@ function _getBidFloors(getFloor, size) {
   const bidFloors = getFloor({
     currency: CURRENCY,
     mediaType: MEDIA_TYPE,
-    size : [ size.w, size.h ]
+    size: [ size.w, size.h ]
   });
 
   if (!isNaN(bidFloors.floor) && (bidFloors.currency === CURRENCY)) {
@@ -354,17 +356,12 @@ function buildRequests(bidRequests, bidderRequest) {
 
   adapterState.uniqueSiteIds = bidRequests.map(req => req.params.siteId).filter(utils.uniques);
 
-  let getFloor;
-  if (typeof bidRequests.getFloor === 'function') {
-    getFloor = bidRequests.getFloor.bind(bidRequests);
-  }
   return bidRequests.map(bidRequest => _createServerRequest(
     {
-      bidRequest, 
-      gdprConsent, 
-      uspConsent, 
-      pageUrl, 
-      getFloor
+      bidRequest,
+      gdprConsent,
+      uspConsent,
+      pageUrl
     })
   );
 }

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -141,7 +141,7 @@ describe('33acrossBidAdapter:', function () {
     };
 
     this.withFormatFloors = floors => {
-      const format = ttxRequest.imp[0].banner.format.map((fm, i)=> {
+      const format = ttxRequest.imp[0].banner.format.map((fm, i) => {
         return Object.assign(fm, {
           ext: {
             ttx: {
@@ -699,7 +699,7 @@ describe('33acrossBidAdapter:', function () {
 
     context('when price floor module is enabled in bidRequest', function() {
       it('does not set any bidfloors in ttxRequest if there is no floor', function() {
-        bidRequests.getFloor = () => ({});
+        bidRequests[0].getFloor = () => ({});
 
         const ttxRequest = new TtxRequestBuilder()
           .build();
@@ -712,12 +712,12 @@ describe('33acrossBidAdapter:', function () {
       });
 
       it('sets bidfloors in ttxRequest if there is a floor', function() {
-        bidRequests.getFloor = ({size, currency, mediaType}) => {
-          const floor = ( size[0] === 300 && size[1] === 250 ) ? 1.0 : 0.10
+        bidRequests[0].getFloor = ({size, currency, mediaType}) => {
+          const floor = (size[0] === 300 && size[1] === 250) ? 1.0 : 0.10
           return (
             {
-            floor,
-            currency: 'USD'
+              floor,
+              currency: 'USD'
             }
           );
         };
@@ -734,7 +734,6 @@ describe('33acrossBidAdapter:', function () {
         expect(builtServerRequests).to.deep.equal([serverRequest]);
       });
     });
-
   });
 
   describe('interpretResponse', function() {

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -140,6 +140,22 @@ describe('33acrossBidAdapter:', function () {
       return this;
     };
 
+    this.withFormatFloors = floors => {
+      const format = ttxRequest.imp[0].banner.format.map((fm, i)=> {
+        return Object.assign(fm, {
+          ext: {
+            ttx: {
+              bidfloors: [ floors[i] ]
+            }
+          }
+        })
+      });
+
+      ttxRequest.imp[0].banner.format = format;
+
+      return this;
+    };
+
     this.build = () => ttxRequest;
   }
 
@@ -667,6 +683,58 @@ describe('33acrossBidAdapter:', function () {
         expect(builtServerRequests).to.deep.equal([serverRequest]);
       });
     });
+
+    context('when price floor module is not enabled in bidRequest', function() {
+      it('does not set any bidfloors in ttxRequest', function() {
+        const ttxRequest = new TtxRequestBuilder()
+          .build();
+        const serverRequest = new ServerRequestBuilder()
+          .withData(ttxRequest)
+          .build();
+        const builtServerRequests = spec.buildRequests(bidRequests, {});
+
+        expect(builtServerRequests).to.deep.equal([serverRequest]);
+      });
+    });
+
+    context('when price floor module is enabled in bidRequest', function() {
+      it('does not set any bidfloors in ttxRequest if there is no floor', function() {
+        bidRequests.getFloor = () => ({});
+
+        const ttxRequest = new TtxRequestBuilder()
+          .build();
+        const serverRequest = new ServerRequestBuilder()
+          .withData(ttxRequest)
+          .build();
+        const builtServerRequests = spec.buildRequests(bidRequests, {});
+
+        expect(builtServerRequests).to.deep.equal([serverRequest]);
+      });
+
+      it('sets bidfloors in ttxRequest if there is a floor', function() {
+        bidRequests.getFloor = ({size, currency, mediaType}) => {
+          const floor = ( size[0] === 300 && size[1] === 250 ) ? 1.0 : 0.10
+          return (
+            {
+            floor,
+            currency: 'USD'
+            }
+          );
+        };
+
+        const ttxRequest = new TtxRequestBuilder()
+          .withFormatFloors([ 1.0, 0.10 ])
+          .build();
+
+        const serverRequest = new ServerRequestBuilder()
+          .withData(ttxRequest)
+          .build();
+        const builtServerRequests = spec.buildRequests(bidRequests, {});
+
+        expect(builtServerRequests).to.deep.equal([serverRequest]);
+      });
+    });
+
   });
 
   describe('interpretResponse', function() {


### PR DESCRIPTION
## BidFloors Support

The adapter does bidfloors as follows:
- If bidfloors module is enabled obtain bidfloor for each format size
- If there's a floor for the given size set it in the `ext.ttx.bidfloors` field
- Else set nothing
- If bidfloors module is not enabled set nothing.

## References
http://prebid.org/dev-docs/modules/floors.html