### PR TITLE
Xch 2158 support userid

### DIFF
--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -202,7 +202,7 @@ function _createServerRequest({bidRequest, gdprConsent = {}, uspConsent, pageUrl
     )
   }
 
-  if (Array.isArray(bidRequest.userIdAsEids)) {
+  if (Array.isArray(bidRequest.userIdAsEids) && bidRequest.userIdAsEids.length > 0) {
     ttxRequest.user = setExtension(
       ttxRequest.user,
       'eids',

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -210,19 +210,11 @@ function _createServerRequest({bidRequest, gdprConsent = {}, uspConsent, pageUrl
     )
   }
 
-  if (gdprConsent.gdprApplies === true) {
-    ttxRequest.regs = setExtension(
-      ttxRequest.regs,
-      'gdpr',
-      1
-    )
-  } else {
-    ttxRequest.regs = setExtension(
-      ttxRequest.regs,
-      'gdpr',
-      0
-    )
-  }
+  ttxRequest.regs = setExtension(
+    ttxRequest.regs,
+    'gdpr',
+    Number(gdprConsent.gdprApplies)
+  );
 
   if (uspConsent) {
     ttxRequest.regs = setExtension(

--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -194,18 +194,44 @@ function _createServerRequest({bidRequest, gdprConsent = {}, uspConsent, pageUrl
   // therefore in ad targetting process
   ttxRequest.id = bidRequest.bidId;
 
-  // Set GDPR related fields
-  ttxRequest.user = {
-    ext: {
-      consent: gdprConsent.consentString
-    }
-  };
-  ttxRequest.regs = {
-    ext: {
-      gdpr: (gdprConsent.gdprApplies === true) ? 1 : 0,
-      us_privacy: uspConsent || null
-    }
-  };
+  if (gdprConsent.consentString) {
+    ttxRequest.user = setExtension(
+      ttxRequest.user,
+      'consent',
+      gdprConsent.consentString
+    )
+  }
+
+  if (Array.isArray(bidRequest.userIdAsEids)) {
+    ttxRequest.user = setExtension(
+      ttxRequest.user,
+      'eids',
+      bidRequest.userIdAsEids
+    )
+  }
+
+  if (gdprConsent.gdprApplies === true) {
+    ttxRequest.regs = setExtension(
+      ttxRequest.regs,
+      'gdpr',
+      1
+    )
+  } else {
+    ttxRequest.regs = setExtension(
+      ttxRequest.regs,
+      'gdpr',
+      0
+    )
+  }
+
+  if (uspConsent) {
+    ttxRequest.regs = setExtension(
+      ttxRequest.regs,
+      'us_privacy',
+      uspConsent
+    )
+  }
+
   ttxRequest.ext = {
     ttx: {
       prebidStartedAt: Date.now(),
@@ -217,11 +243,11 @@ function _createServerRequest({bidRequest, gdprConsent = {}, uspConsent, pageUrl
   };
 
   if (bidRequest.schain) {
-    ttxRequest.source = {
-      ext: {
-        schain: bidRequest.schain
-      }
-    }
+    ttxRequest.source = setExtension(
+      ttxRequest.source,
+      'schain',
+      bidRequest.schain
+    )
   }
 
   // Finally, set the openRTB 'test' param if this is to be a test bid
@@ -248,6 +274,15 @@ function _createServerRequest({bidRequest, gdprConsent = {}, uspConsent, pageUrl
     'data': JSON.stringify(ttxRequest),
     'options': options
   }
+}
+
+// BUILD REQUESTS: SET EXTENSIONS
+function setExtension(obj = {}, key, value) {
+  return Object.assign({}, obj, {
+    ext: Object.assign({}, obj.ext, {
+      [key]: value
+    })
+  });
 }
 
 // BUILD REQUESTS: SIZE INFERENCE

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -589,8 +589,8 @@ describe('33acrossBidAdapter:', function () {
 
         Object.assign(element, { width: 600, height: 400 });
 
-        const builtRequests = spec.buildRequests(bidRequests);
-        validateBuiltServerRequest(builtRequests[0], serverRequest);
+        const [ buildRequest ] = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(buildRequest, serverRequest);
       });
     });
 
@@ -607,8 +607,8 @@ describe('33acrossBidAdapter:', function () {
 
         Object.assign(element, { x: -300, y: 0, width: 207, height: 320 });
 
-        const builtRequests = spec.buildRequests(bidRequests);
-        validateBuiltServerRequest(builtRequests[0], serverRequest);
+        const [ buildRequest ] = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(buildRequest, serverRequest);
       });
     });
 
@@ -625,8 +625,8 @@ describe('33acrossBidAdapter:', function () {
 
         Object.assign(element, { width: 800, height: 800 });
 
-        const builtRequests = spec.buildRequests(bidRequests);
-        validateBuiltServerRequest(builtRequests[0], serverRequest);
+        const [ buildRequest ] = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(buildRequest, serverRequest);
       });
     });
 
@@ -645,8 +645,8 @@ describe('33acrossBidAdapter:', function () {
         Object.assign(element, { width: 0, height: 0 });
         bidRequests[0].mediaTypes.banner.sizes = [[800, 2400]];
 
-        const builtRequests = spec.buildRequests(bidRequests);
-        validateBuiltServerRequest(builtRequests[0], serverRequest);
+        const [ buildRequest ] = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(buildRequest, serverRequest);
       });
     });
 
@@ -668,8 +668,8 @@ describe('33acrossBidAdapter:', function () {
         sandbox.stub(utils, 'getWindowTop').returns({});
         sandbox.stub(utils, 'getWindowSelf').returns(win);
 
-        const builtRequests = spec.buildRequests(bidRequests);
-        validateBuiltServerRequest(builtRequests[0], serverRequest);
+        const [ buildRequest ] = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(buildRequest, serverRequest);
       });
     });
 
@@ -690,8 +690,8 @@ describe('33acrossBidAdapter:', function () {
         win.document.visibilityState = 'hidden';
         sandbox.stub(utils, 'getWindowTop').returns(win);
 
-        const builtRequests = spec.buildRequests(bidRequests);
-        validateBuiltServerRequest(builtRequests[0], serverRequest);
+        const [ buildRequest ] = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(buildRequest, serverRequest);
       });
     });
 
@@ -716,9 +716,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, bidderRequest);
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
 
       it('returns corresponding test server requests with gdpr consent data', function() {
@@ -737,9 +737,9 @@ describe('33acrossBidAdapter:', function () {
           .withData(ttxRequest)
           .withUrl('https://foo.com/hb/')
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, bidderRequest);
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -758,9 +758,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, bidderRequest);
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
 
       it('returns corresponding test server requests with default gdpr consent data', function() {
@@ -778,9 +778,9 @@ describe('33acrossBidAdapter:', function () {
           .withData(ttxRequest)
           .withUrl('https://foo.com/hb/')
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, bidderRequest);
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -802,9 +802,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, bidderRequest);
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
 
       it('returns corresponding test server requests with us_privacy consent data', function() {
@@ -823,9 +823,9 @@ describe('33acrossBidAdapter:', function () {
           .withData(ttxRequest)
           .withUrl('https://foo.com/hb/')
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, bidderRequest);
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -844,9 +844,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, bidderRequest);
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
 
       it('returns corresponding test server requests with default us_privacy consent data', function() {
@@ -864,9 +864,9 @@ describe('33acrossBidAdapter:', function () {
           .withData(ttxRequest)
           .withUrl('https://foo.com/hb/')
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, bidderRequest);
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -887,9 +887,9 @@ describe('33acrossBidAdapter:', function () {
           .withData(ttxRequest)
           .build();
 
-        const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, bidderRequest);
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -907,9 +907,9 @@ describe('33acrossBidAdapter:', function () {
           .withData(ttxRequest)
           .build();
 
-        const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, bidderRequest);
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -961,9 +961,9 @@ describe('33acrossBidAdapter:', function () {
             .withData(ttxRequest)
             .build();
 
-          const builtServerRequests = spec.buildRequests(bidRequests, {});
+          const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-          validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+          validateBuiltServerRequest(builtServerRequest, serverRequest);
         });
       });
     });
@@ -979,9 +979,9 @@ describe('33acrossBidAdapter:', function () {
           .withData(ttxRequest)
           .build();
 
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -994,9 +994,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -1011,9 +1011,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
 
       it('sets bidfloors in ttxRequest if there is a floor', function() {
@@ -1036,9 +1036,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -1061,9 +1061,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
 
       it('builds instream request with params passed', function() {
@@ -1078,9 +1078,9 @@ describe('33acrossBidAdapter:', function () {
           .withProduct('instream')
           .build();
 
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        expect(JSON.parse(builtServerRequests[0].data)).to.deep.equal(ttxRequest);
+        expect(JSON.parse(builtServerRequest.data)).to.deep.equal(ttxRequest);
       });
     });
 
@@ -1102,9 +1102,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
 
       it('builds siab request with video params passed', function() {
@@ -1122,9 +1122,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -1144,9 +1144,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
 
       it('builds default inview request when product is set as such', function() {
@@ -1165,9 +1165,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -1189,9 +1189,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
 
       it('builds siab request with banner and outstream video even when context is instream', function() {
@@ -1213,9 +1213,9 @@ describe('33acrossBidAdapter:', function () {
         const serverRequest = new ServerRequestBuilder()
           .withData(ttxRequest)
           .build();
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
+        validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
     });
 
@@ -1234,9 +1234,9 @@ describe('33acrossBidAdapter:', function () {
           .withProduct()
           .build();
 
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        expect(JSON.parse(builtServerRequests[0].data)).to.deep.equal(ttxRequest);
+        expect(JSON.parse(builtServerRequest.data)).to.deep.equal(ttxRequest);
       });
 
       it('sets bidfloors in video if there is a floor', function() {
@@ -1262,9 +1262,9 @@ describe('33acrossBidAdapter:', function () {
           .withFloors('video', [ 1.0 ])
           .build();
 
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        expect(JSON.parse(builtServerRequests[0].data)).to.deep.equal(ttxRequest);
+        expect(JSON.parse(builtServerRequest.data)).to.deep.equal(ttxRequest);
       });
     });
 
@@ -1304,10 +1304,11 @@ describe('33acrossBidAdapter:', function () {
           .withProduct()
           .build();
 
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        expect(JSON.parse(builtServerRequests[0].data)).to.deep.equal(ttxRequest);
+        expect(JSON.parse(builtServerRequest.data)).to.deep.equal(ttxRequest);
       });
+
       it('does not validate eids ORTB', function() {
         const eids = [1, 2, 3];
 
@@ -1322,51 +1323,57 @@ describe('33acrossBidAdapter:', function () {
           .withProduct()
           .build();
 
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+        const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        expect(JSON.parse(builtServerRequests[0].data)).to.deep.equal(ttxRequest);
+        expect(JSON.parse(builtServerRequest.data)).to.deep.equal(ttxRequest);
       });
     });
 
-    context('when user IDs do not exist under the userIdAsEids field in bidRequest as an Array', function() {
+    context('when user IDs do not exist under the userIdAsEids field in bidRequest as a non-empty Array', function() {
       it('does not pass user IDs in the bidRequest ORTB', function() {
-        const eids = 'foo';
+        const eidsScenarios = [
+          'foo',
+          [],
+          {foo: 1}
+        ];
 
-        const bidRequests = (
-          new BidRequestsBuilder()
-            .withUserIds(eids)
-            .build()
-        );
-        bidRequests.userId = {
-          'vendorx': {
-            'source': 'x-device-vendor-x.com',
-            'uids': [
-              {
-                'id': 'yyy',
-                'atype': 1
-              },
-              {
-                'id': 'zzz',
-                'atype': 1
-              },
-              {
-                'id': 'DB700403-9A24-4A4B-A8D5-8A0B4BE777D2',
-                'atype': 2
+        eidsScenarios.forEach((eids) => {
+          const bidRequests = (
+            new BidRequestsBuilder()
+              .withUserIds(eids)
+              .build()
+          );
+          bidRequests.userId = {
+            'vendorx': {
+              'source': 'x-device-vendor-x.com',
+              'uids': [
+                {
+                  'id': 'yyy',
+                  'atype': 1
+                },
+                {
+                  'id': 'zzz',
+                  'atype': 1
+                },
+                {
+                  'id': 'DB700403-9A24-4A4B-A8D5-8A0B4BE777D2',
+                  'atype': 2
+                }
+              ],
+              'ext': {
+                'foo': 'bar'
               }
-            ],
-            'ext': {
-              'foo': 'bar'
             }
-          }
-        };
+          };
 
-        const ttxRequest = new TtxRequestBuilder()
-          .withProduct()
-          .build();
+          const ttxRequest = new TtxRequestBuilder()
+            .withProduct()
+            .build();
 
-        const builtServerRequests = spec.buildRequests(bidRequests, {});
+          const [ builtServerRequest ] = spec.buildRequests(bidRequests, {});
 
-        expect(JSON.parse(builtServerRequests[0].data)).to.deep.equal(ttxRequest);
+          expect(JSON.parse(builtServerRequest.data)).to.deep.equal(ttxRequest);
+        });
       });
     });
   });

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -5,6 +5,14 @@ import { config } from 'src/config.js';
 
 import { spec } from 'modules/33acrossBidAdapter.js';
 
+function validateBuiltServerRequest(builtReq, expectedReq) {
+  expect(builtReq.url).to.equal(expectedReq.url);
+  expect(builtReq.options).to.deep.equal(expectedReq.options);
+  expect(JSON.parse(builtReq.data)).to.deep.equal(
+    JSON.parse(expectedReq.data)
+  )
+}
+
 describe('33acrossBidAdapter:', function () {
   const BIDDER_CODE = '33across';
   const SITE_ID = 'sample33xGUID123456789';
@@ -22,14 +30,9 @@ describe('33acrossBidAdapter:', function () {
         id: SITE_ID
       },
       id: 'b1',
-      user: {
-        ext: {
-        }
-      },
       regs: {
         ext: {
-          gdpr: 0,
-          us_privacy: null
+          gdpr: 0
         }
       },
       ext: {
@@ -568,7 +571,8 @@ describe('33acrossBidAdapter:', function () {
 
         Object.assign(element, { width: 600, height: 400 });
 
-        expect(spec.buildRequests(bidRequests)).to.deep.equal([ serverRequest ]);
+        const builtRequests = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(builtRequests[0], serverRequest);
       });
     });
 
@@ -585,7 +589,8 @@ describe('33acrossBidAdapter:', function () {
 
         Object.assign(element, { x: -300, y: 0, width: 207, height: 320 });
 
-        expect(spec.buildRequests(bidRequests)).to.deep.equal([ serverRequest ]);
+        const builtRequests = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(builtRequests[0], serverRequest);
       });
     });
 
@@ -602,7 +607,8 @@ describe('33acrossBidAdapter:', function () {
 
         Object.assign(element, { width: 800, height: 800 });
 
-        expect(spec.buildRequests(bidRequests)).to.deep.equal([ serverRequest ]);
+        const builtRequests = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(builtRequests[0], serverRequest);
       });
     });
 
@@ -621,7 +627,8 @@ describe('33acrossBidAdapter:', function () {
         Object.assign(element, { width: 0, height: 0 });
         bidRequests[0].mediaTypes.banner.sizes = [[800, 2400]];
 
-        expect(spec.buildRequests(bidRequests)).to.deep.equal([ serverRequest ]);
+        const builtRequests = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(builtRequests[0], serverRequest);
       });
     });
 
@@ -643,7 +650,8 @@ describe('33acrossBidAdapter:', function () {
         sandbox.stub(utils, 'getWindowTop').returns({});
         sandbox.stub(utils, 'getWindowSelf').returns(win);
 
-        expect(spec.buildRequests(bidRequests)).to.deep.equal([ serverRequest ]);
+        const builtRequests = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(builtRequests[0], serverRequest);
       });
     });
 
@@ -664,7 +672,8 @@ describe('33acrossBidAdapter:', function () {
         win.document.visibilityState = 'hidden';
         sandbox.stub(utils, 'getWindowTop').returns(win);
 
-        expect(spec.buildRequests(bidRequests)).to.deep.equal([ serverRequest ]);
+        const builtRequests = spec.buildRequests(bidRequests);
+        validateBuiltServerRequest(builtRequests[0], serverRequest);
       });
     });
 
@@ -691,7 +700,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
 
       it('returns corresponding test server requests with gdpr consent data', function() {
@@ -712,7 +721,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 
@@ -733,7 +742,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
 
       it('returns corresponding test server requests with default gdpr consent data', function() {
@@ -753,7 +762,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 
@@ -777,7 +786,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
 
       it('returns corresponding test server requests with us_privacy consent data', function() {
@@ -798,7 +807,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 
@@ -819,7 +828,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
 
       it('returns corresponding test server requests with default us_privacy consent data', function() {
@@ -839,7 +848,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 
@@ -862,7 +871,7 @@ describe('33acrossBidAdapter:', function () {
 
         const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 
@@ -882,7 +891,7 @@ describe('33acrossBidAdapter:', function () {
 
         const builtServerRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 
@@ -936,7 +945,7 @@ describe('33acrossBidAdapter:', function () {
 
           const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-          expect(builtServerRequests).to.deep.equal([serverRequest]);
+          validateBuiltServerRequest(builtServerRequests[0], serverRequest);
         });
       });
     });
@@ -954,7 +963,7 @@ describe('33acrossBidAdapter:', function () {
 
         const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 
@@ -969,7 +978,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 
@@ -986,7 +995,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
 
       it('sets bidfloors in ttxRequest if there is a floor', function() {
@@ -1011,7 +1020,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 
@@ -1036,7 +1045,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
 
       it('builds instream request with params passed', function() {
@@ -1077,7 +1086,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
 
       it('builds siab request with video params passed', function() {
@@ -1097,7 +1106,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 
@@ -1119,7 +1128,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
 
       it('builds default inview request when product is set as such', function() {
@@ -1140,7 +1149,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 
@@ -1164,7 +1173,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
 
       it('builds siab request with banner and outstream video even when context is instream', function() {
@@ -1188,7 +1197,7 @@ describe('33acrossBidAdapter:', function () {
           .build();
         const builtServerRequests = spec.buildRequests(bidRequests, {});
 
-        expect(builtServerRequests).to.deep.equal([serverRequest]);
+        validateBuiltServerRequest(builtServerRequests[0], serverRequest);
       });
     });
 

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -197,6 +197,18 @@ describe('33acrossBidAdapter:', function () {
       return this;
     };
 
+    this.withUserIds = (eids) => {
+      Object.assign(ttxRequest, {
+        user: {
+          ext: {
+            eids
+          }
+        }
+      });
+
+      return this;
+    }
+
     this.build = () => ttxRequest;
   }
 
@@ -272,6 +284,12 @@ describe('33acrossBidAdapter:', function () {
 
       return this;
     }
+
+    this.withUserIds = (eids) => {
+      bidRequests[0].userIdAsEids = eids;
+
+      return this;
+    };
 
     this.build = () => bidRequests;
   }
@@ -1242,6 +1260,108 @@ describe('33acrossBidAdapter:', function () {
           .withVideo()
           .withProduct()
           .withFloors('video', [ 1.0 ])
+          .build();
+
+        const builtServerRequests = spec.buildRequests(bidRequests, {});
+
+        expect(JSON.parse(builtServerRequests[0].data)).to.deep.equal(ttxRequest);
+      });
+    });
+
+    context('when user ID data exists as userIdAsEids Array in bidRequest', function() {
+      it('passes userIds in eids field in ORTB request', function() {
+        const eids = [
+          {
+            'source': 'x-device-vendor-x.com',
+            'uids': [
+              {
+                'id': 'yyy',
+                'atype': 1
+              },
+              {
+                'id': 'zzz',
+                'atype': 1
+              },
+              {
+                'id': 'DB700403-9A24-4A4B-A8D5-8A0B4BE777D2',
+                'atype': 2
+              }
+            ],
+            'ext': {
+              'foo': 'bar'
+            }
+          }
+        ];
+
+        const bidRequests = (
+          new BidRequestsBuilder()
+            .withUserIds(eids)
+            .build()
+        );
+
+        const ttxRequest = new TtxRequestBuilder()
+          .withUserIds(eids)
+          .withProduct()
+          .build();
+
+        const builtServerRequests = spec.buildRequests(bidRequests, {});
+
+        expect(JSON.parse(builtServerRequests[0].data)).to.deep.equal(ttxRequest);
+      });
+      it('does not validate eids ORTB', function() {
+        const eids = [1, 2, 3];
+
+        const bidRequests = (
+          new BidRequestsBuilder()
+            .withUserIds(eids)
+            .build()
+        );
+
+        const ttxRequest = new TtxRequestBuilder()
+          .withUserIds(eids)
+          .withProduct()
+          .build();
+
+        const builtServerRequests = spec.buildRequests(bidRequests, {});
+
+        expect(JSON.parse(builtServerRequests[0].data)).to.deep.equal(ttxRequest);
+      });
+    });
+
+    context('when user IDs do not exist under the userIdAsEids field in bidRequest as an Array', function() {
+      it('does not pass user IDs in the bidRequest ORTB', function() {
+        const eids = 'foo';
+
+        const bidRequests = (
+          new BidRequestsBuilder()
+            .withUserIds(eids)
+            .build()
+        );
+        bidRequests.userId = {
+          'vendorx': {
+            'source': 'x-device-vendor-x.com',
+            'uids': [
+              {
+                'id': 'yyy',
+                'atype': 1
+              },
+              {
+                'id': 'zzz',
+                'atype': 1
+              },
+              {
+                'id': 'DB700403-9A24-4A4B-A8D5-8A0B4BE777D2',
+                'atype': 2
+              }
+            ],
+            'ext': {
+              'foo': 'bar'
+            }
+          }
+        };
+
+        const ttxRequest = new TtxRequestBuilder()
+          .withProduct()
           .build();
 
         const builtServerRequests = spec.buildRequests(bidRequests, {});


### PR DESCRIPTION
- Add support for passing 3P user ID's via Prebid User ID module
- The adapter requires the user IDs to be present in `bidRequest.userIdAsEids` as an Array. It will not read individual sources under `bidRequest` (such as `bidRequest.id5id` etc)
- This PR, in addition, also refactors how extension fields are set. Previously ext fields are set under `user`, `regs`, `source` regardless of whether  or not there is the relevant data (CCPA, GDPR, Schain etc). Therefore the request payload sent out to TTX was needlessly bloated with empty ext field values. In this PR, the `ext` and even the parent fields are conditionally set.
- 
Resolves https://jira.internal.33across.com/browse/XCH-2158