### PR TITLE
Remove client hints from 33across adapter

### DIFF
--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -1,6 +1,5 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
-import { getStorageManager } from '../src/storageManager.js';
 import {
   deepAccess,
   uniques,
@@ -60,44 +59,6 @@ function getTTXConfig() {
   );
 
   return ttxSettings;
-}
-
-export const storage = getStorageManager({gvlid: GVLID, moduleName: BIDDER_CODE})
-export const UA_DATA_KEY = `${BIDDER_CODE}UaReducedData`;
-
-function getStoredUaReducedData() {
-  try {
-    return JSON.parse(storage.getDataFromLocalStorage(UA_DATA_KEY));
-  } catch (err) {
-    return null;
-  }
-}
-
-function storeUaReducedData(uaData) {
-  storage.setDataInLocalStorage(UA_DATA_KEY, JSON.stringify(uaData));
-}
-
-function calculateUaReducedData() {
-  let uaReducedData = {};
-
-  // eslint-disable-next-line no-unused-expressions
-  getWindowSelf().navigator.userAgentData?.getHighEntropyValues(
-    ['model', 'uaFullVersion', 'platformVersion']
-  ).then((uaData) => {
-    uaReducedData = uaData;
-
-    if (Object.values(uaData).find(value => !!value).length) {
-      storeUaReducedData(uaReducedData);
-    }
-  });
-
-  return uaReducedData;
-}
-
-calculateUaReducedData();
-
-function fetchUAReducedData() {
-  return getStoredUaReducedData() || calculateUaReducedData();
 }
 
 // **************************** VALIDATION *************************** //
@@ -781,23 +742,14 @@ function _createSync({ siteId = 'zzz000000000003zzz', gdprConsent = {}, uspConse
 function _buildDeviceORTB() {
   const win = getWindowSelf();
 
-  const {
-    uaFullVersion: uafv,
-    platformVersion: pfv,
-    model
-  } = fetchUAReducedData();
-
   return {
     ext: {
       ttx: {
         ...getScreenDimensions(),
         pxr: win.devicePixelRatio,
-        pfv,
-        ...(model ? { mdl: model } : {}),
         vp: getViewportDimensions(),
         ah: win.screen.availHeight,
-        mtp: win.navigator.maxTouchPoints,
-        uafv
+        mtp: win.navigator.maxTouchPoints
       }
     }
   };

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import * as utils from 'src/utils.js';
 import { config } from 'src/config.js';
 
-import { spec, storage, UA_DATA_KEY } from 'modules/33acrossBidAdapter.js';
+import { spec } from 'modules/33acrossBidAdapter.js';
 
 function validateBuiltServerRequest(builtReq, expectedReq) {
   expect(builtReq.url).to.equal(expectedReq.url);
@@ -36,15 +36,12 @@ describe('33acrossBidAdapter:', function () {
             w: 1024,
             h: 728,
             pxr: 2,
-            pfv: 'fooosversion',
-            mdl: 'foomodel',
             vp: {
               w: 800,
               h: 600
             },
             ah: 500,
-            mtp: 0,
-            uafv: 'foouafullversion'
+            mtp: 0
           }
         }
       },
@@ -403,20 +400,7 @@ describe('33acrossBidAdapter:', function () {
         availHeight: 500
       },
       navigator: {
-        maxTouchPoints: 0,
-        userAgentData: {
-          getHighEntropyValues() {
-            return {
-              then(fn) {
-                fn({
-                  platformVersion: 'fooosversion',
-                  uaFullVersion: 'foouafullversion',
-                  model: 'foomodel'
-                });
-              }
-            }
-          }
-        }
+        maxTouchPoints: 0
       },
       document: {
         visibilityState: 'visible',
@@ -440,10 +424,6 @@ describe('33acrossBidAdapter:', function () {
     sandbox.stub(document, 'getElementById').returns(element);
     sandbox.stub(utils, 'getWindowTop').returns(win);
     sandbox.stub(utils, 'getWindowSelf').returns(win);
-    sandbox
-      .stub(storage, 'getDataFromLocalStorage')
-      .withArgs(UA_DATA_KEY)
-      .returns(null);
   });
 
   afterEach(function() {
@@ -1220,24 +1200,6 @@ describe('33acrossBidAdapter:', function () {
 
         validateBuiltServerRequest(builtServerRequest, serverRequest);
       });
-    });
-
-    it('stores the user agent entropy values', function() {
-      const ttxRequest = new TtxRequestBuilder()
-        .build();
-      const serverRequest = new ServerRequestBuilder()
-        .withData(ttxRequest)
-        .build();
-
-      sandbox.spy(storage, 'setDataInLocalStorage');
-
-      spec.buildRequests(bidRequests);
-
-      sinon.assert.calledWith(storage.setDataInLocalStorage, UA_DATA_KEY, JSON.stringify({
-        platformVersion: 'fooosversion',
-        uaFullVersion: 'foouafullversion',
-        model: 'foomodel'
-      }));
     });
 
     context('when referer value is not available', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!--Remove Client Hints from adapter-->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
