### PR TITLE
IDG-1093: Bugfix: Price floor not reported correctly when CPM adjustment specified

### DIFF
--- a/modules/33acrossAnalyticsAdapter.js
+++ b/modules/33acrossAnalyticsAdapter.js
@@ -503,7 +503,7 @@ function onBidResponse({ requestId, auctionId, cpm, currency, originalCpm, floor
         cpm,
         cur: currency,
         cpmOrig: originalCpm,
-        cpmFloor: floorData?.cpmAfterAdjustments,
+        cpmFloor: floorData?.floorValue,
         mediaType,
         size
       },

--- a/test/spec/modules/33acrossAnalyticsAdapter_spec.js
+++ b/test/spec/modules/33acrossAnalyticsAdapter_spec.js
@@ -970,7 +970,7 @@ function getMockEvents() {
         cpm: 1.5,
         currency: 'USD',
         floorData: {
-          cpmAfterAdjustments: 1
+          floorValue: 1
         },
         mediaType: 'banner',
         originalCpm: 1.5,
@@ -984,7 +984,7 @@ function getMockEvents() {
         cpm: 1.5,
         currency: 'USD',
         floorData: {
-          cpmAfterAdjustments: 1
+          floorValue: 1
         },
         mediaType: 'banner',
         originalCpm: 1.5,
@@ -998,7 +998,7 @@ function getMockEvents() {
         cpm: 1.5,
         currency: 'USD',
         floorData: {
-          cpmAfterAdjustments: 1
+          floorValue: 1
         },
         mediaType: 'banner',
         originalCpm: 1.5,
@@ -1012,7 +1012,7 @@ function getMockEvents() {
         cpm: 1.5,
         currency: 'USD',
         floorData: {
-          cpmAfterAdjustments: 1
+          floorValue: 1
         },
         mediaType: 'banner',
         originalCpm: 1.5,
@@ -1027,7 +1027,7 @@ function getMockEvents() {
         cpm: 1.5,
         currency: 'USD',
         floorData: {
-          cpmAfterAdjustments: 1
+          floorValue: 1
         },
         mediaType: 'banner',
         originalCpm: 1.5,
@@ -1042,7 +1042,7 @@ function getMockEvents() {
         cpm: 1.5,
         currency: 'USD',
         floorData: {
-          cpmAfterAdjustments: 1
+          floorValue: 1
         },
         mediaType: 'banner',
         originalCpm: 1.5,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Use `floorValue` instead of `cpmAfterAdjustments` to obtain price floor from `floorData`. Resolves IDG-1093.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
https://jira.internal.33across.com/browse/IDG-1093
@mscottnelson 
