### PR TITLE
IDG-1107: Bugfix: Mark bid as won on impression only

### DIFF
--- a/modules/33acrossAnalyticsAdapter.js
+++ b/modules/33acrossAnalyticsAdapter.js
@@ -576,7 +576,7 @@ function setBidStatus(bid, status = BidStatus.AVAILABLE) {
     },
   }
 
-  const winningStatuses = [BidStatus.TARGETING_SET, BidStatus.RENDERED];
+  const winningStatuses = [BidStatus.RENDERED];
 
   if (statusStates[bid.status].next.includes(status)) {
     bid.status = status;

--- a/test/spec/modules/33acrossAnalyticsAdapter_spec.js
+++ b/test/spec/modules/33acrossAnalyticsAdapter_spec.js
@@ -456,7 +456,19 @@ describe('33acrossAnalyticsAdapter:', function () {
       });
 
       context('and the incomplete report has been sent successfully', function () {
-        it('sends a report string with any bids with targetingSet status set to hasWon: 1', function () {
+        it('sends a report string with any bids with rendered status set to hasWon: 1', function () {
+          navigator.sendBeacon.returns(true);
+
+          this.enableAnalytics();
+
+          performStandardAuction({exclude: ['auctionEnd']});
+          sandbox.clock.tick(this.defaultTimeout + 1000);
+
+          const incompleteSentBid = JSON.parse(navigator.sendBeacon.firstCall.args[1]).auctions[0].adUnits[1].bids[0];
+          assert.strictEqual(incompleteSentBid.hasWon, 1);
+        });
+
+        it('reports bids with only targetingSet status as hasWon: 0', function () {
           navigator.sendBeacon.returns(true);
 
           this.enableAnalytics();
@@ -465,7 +477,7 @@ describe('33acrossAnalyticsAdapter:', function () {
           sandbox.clock.tick(this.defaultTimeout + 1000);
 
           const incompleteSentBid = JSON.parse(navigator.sendBeacon.firstCall.args[1]).auctions[0].adUnits[1].bids[0];
-          assert.strictEqual(incompleteSentBid.hasWon, 1);
+          assert.strictEqual(incompleteSentBid.hasWon, 0);
         });
 
         it('logs an info message', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
The 33Across Analytics adapter marks a bid as having won as soon as Prebid.js sets targeting parameters for it. The adapter should instead wait until the impression is actually rendered to do so, matching the behavior of the other major analytics adapters.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
https://jira.internal.33across.com/browse/IDG-1107

<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
