### PR TITLE
IDG-1163:: Improve slotRenderEnded Matching

### DIFF
--- a/modules/33acrossAnalyticsAdapter.js
+++ b/modules/33acrossAnalyticsAdapter.js
@@ -288,7 +288,8 @@ function calculateTransactionTimeout(configTimeout = DEFAULT_TRANSACTION_TIMEOUT
 function subscribeToGamSlots() {
   window.googletag.pubads().addEventListener('slotRenderEnded', event => {
     setTimeout(() => {
-      const { transactionId, auctionId } = getAdUnitMetadata(event.slot.getAdUnitPath());
+      const { transactionId, auctionId } =
+          getAdUnitMetadata(event.slot.getAdUnitPath(), event.slot.getSlotElementId());
       if (!transactionId || !auctionId) {
         const slotName = `${event.slot.getAdUnitPath()} - ${event.slot.getSlotElementId()}`;
         log.warn('Could not find configured ad unit matching GAM render of slot:', { slotName });
@@ -301,8 +302,8 @@ function subscribeToGamSlots() {
   });
 }
 
-function getAdUnitMetadata(adUnitCode) {
-  const adUnitMeta = locals.adUnitMap[adUnitCode];
+function getAdUnitMetadata(adUnitPath, adSlotElementId) {
+  const adUnitMeta = locals.adUnitMap[adUnitPath] || locals.adUnitMap[adSlotElementId];
   if (adUnitMeta && adUnitMeta.length > 0) {
     return adUnitMeta[adUnitMeta.length - 1];
   }

--- a/modules/33acrossAnalyticsAdapter.js
+++ b/modules/33acrossAnalyticsAdapter.js
@@ -289,6 +289,12 @@ function subscribeToGamSlots() {
   window.googletag.pubads().addEventListener('slotRenderEnded', event => {
     setTimeout(() => {
       const { transactionId, auctionId } = getAdUnitMetadata(event.slot.getAdUnitPath());
+      if (!transactionId || !auctionId) {
+        const slotName = `${event.slot.getAdUnitPath()} - ${event.slot.getSlotElementId()}`;
+        log.warn('Could not find configured ad unit matching GAM render of slot:', { slotName });
+        return;
+      }
+
       locals.transactionManagers[auctionId] &&
         locals.transactionManagers[auctionId].complete(transactionId);
     }, POST_GAM_TIMEOUT);
@@ -300,6 +306,7 @@ function getAdUnitMetadata(adUnitCode) {
   if (adUnitMeta && adUnitMeta.length > 0) {
     return adUnitMeta[adUnitMeta.length - 1];
   }
+  return {};
 }
 
 /** necessary for testing */


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->
Allow ad units to be configured with slot element ID instead of GAM ad unit code.
Error out more gracefully when ad unit code is invalid.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
https://jira.internal.33across.com/browse/IDG-1163
@mscottnelson 
