### PR TITLE
Introduce first-party ID support to 33Across User ID sub-module.

### DIFF
--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -9,32 +9,42 @@ import { logMessage, logError } from '../src/utils.js';
 import { ajaxBuilder } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
 import { uspDataHandler, coppaDataHandler, gppDataHandler } from '../src/adapterManager.js';
+import { getStorageManager } from '../src/storageManager.js';
+import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 
 const MODULE_NAME = '33acrossId';
 const API_URL = 'https://lexicon.33across.com/v1/envelope';
 const AJAX_TIMEOUT = 10000;
 const CALLER_NAME = 'pbjs';
+const GVLID = 58;
 
-function getEnvelope(response) {
+const STORAGE_FPID_KEY = '33acrossIdFp';
+
+export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
+
+function calculateResponseObj(response) {
   if (!response.succeeded) {
     if (response.error == 'Cookied User') {
       logMessage(`${MODULE_NAME}: Unsuccessful response`.concat(' ', response.error));
     } else {
       logError(`${MODULE_NAME}: Unsuccessful response`.concat(' ', response.error));
     }
-    return;
+    return {};
   }
 
   if (!response.data.envelope) {
     logMessage(`${MODULE_NAME}: No envelope was received`);
 
-    return;
+    return {};
   }
 
-  return response.data.envelope;
+  return {
+    envelope: response.data.envelope,
+    fp: response.data.fp
+  };
 }
 
-function calculateQueryStringParams(pid, gdprConsentData) {
+function calculateQueryStringParams(pid, gdprConsentData, storedId) {
   const uspString = uspDataHandler.getConsentData();
   const gdprApplies = Boolean(gdprConsentData?.gdprApplies);
   const coppaValue = coppaDataHandler.getCoppa();
@@ -63,6 +73,11 @@ function calculateQueryStringParams(pid, gdprConsentData) {
     params.gdpr_consent = gdprConsentData.consentString;
   }
 
+  const fp = storage.getDataFromLocalStorage(STORAGE_FPID_KEY);
+  if (storedId && fp) {
+    params.fp = fp;
+  }
+
   return params;
 }
 
@@ -74,7 +89,7 @@ export const thirthyThreeAcrossIdSubmodule = {
    */
   name: MODULE_NAME,
 
-  gvlid: 58,
+  gvlid: GVLID,
 
   /**
    * decode the stored id value for passing to bid requests
@@ -96,7 +111,7 @@ export const thirthyThreeAcrossIdSubmodule = {
    * @param {SubmoduleConfig} [config]
    * @returns {IdResponse|undefined}
    */
-  getId({ params = { } }, gdprConsentData) {
+  getId({ params = { } }, gdprConsentData, storedId) {
     if (typeof params.pid !== 'string') {
       logError(`${MODULE_NAME}: Submodule requires a partner ID to be defined`);
 
@@ -109,21 +124,26 @@ export const thirthyThreeAcrossIdSubmodule = {
       callback(cb) {
         ajaxBuilder(AJAX_TIMEOUT)(apiUrl, {
           success(response) {
-            let envelope;
+            let responseObj = { };
 
             try {
-              envelope = getEnvelope(JSON.parse(response))
+              responseObj = calculateResponseObj(JSON.parse(response));
             } catch (err) {
               logError(`${MODULE_NAME}: ID reading error:`, err);
             }
-            cb(envelope);
+
+            if (responseObj.fp) {
+              storage.setDataInLocalStorage(STORAGE_FPID_KEY, responseObj.fp);
+            }
+
+            cb(responseObj.envelope);
           },
           error(err) {
             logError(`${MODULE_NAME}: ID error response`, err);
 
             cb();
           }
-        }, calculateQueryStringParams(pid, gdprConsentData), { method: 'GET', withCredentials: true });
+        }, calculateQueryStringParams(pid, gdprConsentData, storedId), { method: 'GET', withCredentials: true });
       }
     };
   },

--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -44,7 +44,7 @@ function calculateResponseObj(response) {
   };
 }
 
-function calculateQueryStringParams(pid, gdprConsentData, storedId) {
+function calculateQueryStringParams(pid, gdprConsentData) {
   const uspString = uspDataHandler.getConsentData();
   const gdprApplies = Boolean(gdprConsentData?.gdprApplies);
   const coppaValue = coppaDataHandler.getCoppa();
@@ -74,7 +74,7 @@ function calculateQueryStringParams(pid, gdprConsentData, storedId) {
   }
 
   const fp = storage.getDataFromLocalStorage(STORAGE_FPID_KEY);
-  if (storedId && fp) {
+  if (fp) {
     params.fp = fp;
   }
 
@@ -111,7 +111,7 @@ export const thirthyThreeAcrossIdSubmodule = {
    * @param {SubmoduleConfig} [config]
    * @returns {IdResponse|undefined}
    */
-  getId({ params = { } }, gdprConsentData, storedId) {
+  getId({ params = { } }, gdprConsentData) {
     if (typeof params.pid !== 'string') {
       logError(`${MODULE_NAME}: Submodule requires a partner ID to be defined`);
 
@@ -134,6 +134,8 @@ export const thirthyThreeAcrossIdSubmodule = {
 
             if (responseObj.fp) {
               storage.setDataInLocalStorage(STORAGE_FPID_KEY, responseObj.fp);
+            } else {
+              storage.removeDataFromLocalStorage(STORAGE_FPID_KEY);
             }
 
             cb(responseObj.envelope);
@@ -143,7 +145,7 @@ export const thirthyThreeAcrossIdSubmodule = {
 
             cb();
           }
-        }, calculateQueryStringParams(pid, gdprConsentData, storedId), { method: 'GET', withCredentials: true });
+        }, calculateQueryStringParams(pid, gdprConsentData), { method: 'GET', withCredentials: true });
       }
     };
   },


### PR DESCRIPTION
Enhance the 33Across User ID sub-module to support setting a first-party ID in addition to the primary ID envelope.

Details: https://jira.internal.33across.com/browse/IDG-1216

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
