### PR TITLE
Clear stored 33x ID when response doesn't return an "envelope" ID

### DIFF
--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -146,7 +146,7 @@ export const thirthyThreeAcrossIdSubmodule = {
    * @param {SubmoduleConfig} [config]
    * @returns {IdResponse|undefined}
    */
-  getId({ params = { }, storage }, gdprConsentData) {
+  getId({ params = { }, storage: storageConfig }, gdprConsentData) {
     if (typeof params.pid !== 'string') {
       logError(`${MODULE_NAME}: Submodule requires a partner ID to be defined`);
 
@@ -167,7 +167,11 @@ export const thirthyThreeAcrossIdSubmodule = {
               logError(`${MODULE_NAME}: ID reading error:`, err);
             }
 
-            handleFpId(responseObj.fp, storage);
+            if (!responseObj.envelope) {
+              deleteFromStorage(MODULE_NAME);
+            }
+
+            handleFpId(responseObj.fp, storageConfig);
 
             cb(responseObj.envelope);
           },
@@ -176,7 +180,7 @@ export const thirthyThreeAcrossIdSubmodule = {
 
             cb();
           }
-        }, calculateQueryStringParams(pid, gdprConsentData, storage), { method: 'GET', withCredentials: true });
+        }, calculateQueryStringParams(pid, gdprConsentData, storageConfig), { method: 'GET', withCredentials: true });
       }
     };
   },

--- a/test/spec/modules/33acrossIdSystem_spec.js
+++ b/test/spec/modules/33acrossIdSystem_spec.js
@@ -127,8 +127,8 @@ describe('33acrossIdSystem', () => {
       });
     });
 
-    context('if the response doesn\'t include a first-party ID', () => {
-      it('should try to remove any first-party ID that could be stored', () => {
+    context('if the response lacks a first-party ID', () => {
+      it('should wipe any existing first-party ID from storage', () => {
         const completeCallback = () => {};
 
         const { callback } = thirthyThreeAcrossIdSubmodule.getId({
@@ -164,38 +164,6 @@ describe('33acrossIdSystem', () => {
         removeDataFromLocalStorage.restore();
         setCookie.restore();
         cookiesAreEnabled.restore();
-      });
-    });
-
-    context('if the response lacks a first-party ID', () => {
-      it('should wipe any existing first-party ID from storage', () => {
-        const completeCallback = () => {};
-
-        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
-          params: {
-            pid: '12345'
-          }
-        });
-
-        callback(completeCallback);
-
-        const [request] = server.requests;
-
-        const removeDataFromLocalStorage = sinon.stub(storage, 'removeDataFromLocalStorage');
-
-        request.respond(200, {
-          'Content-Type': 'application/json'
-        }, JSON.stringify({
-          succeeded: true,
-          data: {
-            envelope: 'foo'
-          },
-          expires: 1645667805067
-        }));
-
-        expect(removeDataFromLocalStorage.calledOnceWithExactly('33acrossIdFp')).to.be.true;
-
-        removeDataFromLocalStorage.restore();
       });
     });
 

--- a/test/spec/modules/33acrossIdSystem_spec.js
+++ b/test/spec/modules/33acrossIdSystem_spec.js
@@ -167,6 +167,46 @@ describe('33acrossIdSystem', () => {
       });
     });
 
+    context('if the response lacks the 33across "envelope" ID', () => {
+      it('should wipe any existing "envelope" ID from storage', () => {
+        const completeCallback = () => {};
+
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          },
+          storage: {
+            type: 'html5'
+          }
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        const removeDataFromLocalStorage = sinon.stub(storage, 'removeDataFromLocalStorage');
+        const setCookie = sinon.stub(storage, 'setCookie');
+        const cookiesAreEnabled = sinon.stub(storage, 'cookiesAreEnabled').returns(true);
+
+        request.respond(200, {
+          'Content-Type': 'application/json'
+        }, JSON.stringify({
+          succeeded: true,
+          data: {
+            envelope: '' // no 'envelope' field
+          },
+          expires: 1645667805067
+        }));
+
+        expect(removeDataFromLocalStorage.calledWith('33acrossId')).to.be.true;
+        expect(setCookie.calledWith('33acrossId', '', sinon.match.string, 'Lax')).to.be.true;
+
+        removeDataFromLocalStorage.restore();
+        setCookie.restore();
+        cookiesAreEnabled.restore();
+      });
+    });
+
     context('when GDPR applies', () => {
       it('should call endpoint with \'gdpr=1\'', () => {
         const completeCallback = () => {};


### PR DESCRIPTION
Once the envelope is stored, there could be the case that during the "refresh" request the response no longer returns an envelope, perhaps the user has opted-out OR has changed his privacy setting in a way that there's no privacy consent anymore. On those scenarios the envelope stored in a cookie or in  local storage should be removed.