### PR TITLE
IDG-1362 change expire recommendation from 90 to 30

### DIFF
--- a/modules/33acrossIdSystem.md
+++ b/modules/33acrossIdSystem.md
@@ -15,7 +15,7 @@ pbjs.setConfig({
         storage: {
           name: "33acrossId",
           type: "html5",
-          expires: 90,
+          expires: 30,
           refreshInSeconds: 8*3600
         },
         params: {
@@ -41,7 +41,7 @@ The following settings are available for the `storage` property in the `userSync
 | --- | --- | --- | --- | --- |
 | name | Required | String| Name of the cookie or HTML5 local storage where the user ID will be stored | `"33acrossId"` |
 | type | Required | String | `"html5"` (preferred)  or `"cookie"` | `"html5"` |
-| expires | Strongly Recommended | Number | How long (in days) the user ID information will be stored. 33Across recommends `90`. | `90` |
+| expires | Strongly Recommended | Number | How long (in days) the user ID information will be stored. 33Across recommends `30`. | `30` |
 | refreshInSeconds | Strongly Recommended | Number | The interval (in seconds) for refreshing the user ID. 33Across recommends no more than 8 hours between refreshes. | `8*3600` |
 
 ### Params


### PR DESCRIPTION
Change expire recommendation from 90 to 30 days

UIM - no changes since there are no default expire values in place